### PR TITLE
Add detect-secrets integration with GitHub Actions and Makefile

### DIFF
--- a/.github/workflows/detect-secrets.yaml
+++ b/.github/workflows/detect-secrets.yaml
@@ -1,0 +1,42 @@
+name: Detect Secrets Scan
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [master]
+
+jobs:
+  detect-secrets:
+    name: Scan for Secrets (uses committed baseline config)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install detect-secrets
+        run: pip install git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets
+
+      - name: Compare baseline
+        run: |
+          cp .secrets.baseline .secrets.baseline.bak
+          detect-secrets scan --update .secrets.baseline --suppress-unscannable-file-warnings
+
+          grep -v '"generated_at":' .secrets.baseline.bak > before.cleaned
+          grep -v '"generated_at":' .secrets.baseline     > after.cleaned
+
+          if ! diff before.cleaned after.cleaned > secrets.diff; then
+            echo "::error::Secrets baseline changed (excluding timestamp)."
+            cat secrets.diff
+            rm .secrets.baseline.bak before.cleaned after.cleaned secrets.diff
+            exit 1
+          else
+            echo "✅ No actual secret changes detected."
+            rm .secrets.baseline.bak before.cleaned after.cleaned secrets.diff
+          fi

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,858 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2025-08-01T05:27:26Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "api/active_tasks.md": [
+      {
+        "hashed_secret": "93775a911315057185d89e47e6582deb9eb7b84c",
+        "is_verified": false,
+        "line_number": 116,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c92287c48e2334beb4c6167f9d311285756a1518",
+        "is_verified": false,
+        "line_number": 125,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "api/advanced.md": [
+      {
+        "hashed_secret": "8c7fcb0678370a809c1e9c8c0c5ab5896b96fa97",
+        "is_verified": false,
+        "line_number": 399,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "200b9e3ef61c81963d0b921497582b6dabc13d95",
+        "is_verified": false,
+        "line_number": 568,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8f53560c432f96a9d8d426eb1b2cfd736e473cdf",
+        "is_verified": false,
+        "line_number": 613,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "141ab7bf2677a0f1b70d9c25508fe5377f1f46b4",
+        "is_verified": false,
+        "line_number": 614,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b6f6b3e5ca6958e52bc66c734d1036cbb9158b6",
+        "is_verified": false,
+        "line_number": 615,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "102c2105f13e4e2c9e32df12c38ab32cf70534e9",
+        "is_verified": false,
+        "line_number": 616,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8badc6d24881d70ff52a7d57afb283fc1e6499de",
+        "is_verified": false,
+        "line_number": 617,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "api/advanced_replication.md": [
+      {
+        "hashed_secret": "5c050b8084c153d0f8604a7155a37af9439d3af7",
+        "is_verified": false,
+        "line_number": 448,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "api/authentication.md": [
+      {
+        "hashed_secret": "4927ce044fedb4d40f27567d77d152884e1650b9",
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5036b6f1203c130f3a71470b2e7de04ce5eed2ce",
+        "is_verified": false,
+        "line_number": 299,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "55b4c0715fbfb9ca9bd5c68f2172ed334750419c",
+        "is_verified": false,
+        "line_number": 299,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "api/authorization.md": [
+      {
+        "hashed_secret": "b823b0532e8a1a163813f6703318de76b306f209",
+        "is_verified": false,
+        "line_number": 431,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "api/cloudant-geo.md": [
+      {
+        "hashed_secret": "d9ba223e268b7897af8a111c5de0feea25b444bc",
+        "is_verified": false,
+        "line_number": 149,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "87f9e0316de1e2089130685278d1cc5bc70b1a6a",
+        "is_verified": false,
+        "line_number": 448,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c2f7fe97ae941ade2af8c9262f685ae3dd05ad83",
+        "is_verified": false,
+        "line_number": 470,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "adfec640f1a0f0ec75486d371560b082b0a4cedf",
+        "is_verified": false,
+        "line_number": 551,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "00d4303767e3ac3ff43b52006a123d66ed39f2c1",
+        "is_verified": false,
+        "line_number": 554,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eb61dc04c64012b5ea9208b2db1c7bbe91fb3d8c",
+        "is_verified": false,
+        "line_number": 593,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1fc5e494b818d456127be05664c69a3cb445c764",
+        "is_verified": false,
+        "line_number": 596,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c512821069784a79b370bf5faf3d41857e17041d",
+        "is_verified": false,
+        "line_number": 608,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "api/cloudant_query.md": [
+      {
+        "hashed_secret": "6287c8d267c970117ee457ff8e593cd37a905957",
+        "is_verified": false,
+        "line_number": 1920,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b7640df8f8299e63206817e5d3fc207cc7c997d4",
+        "is_verified": false,
+        "line_number": 2253,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5cecaf6adbd8e7339960dfc79286d0a8fddf2e5a",
+        "is_verified": false,
+        "line_number": 2350,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "api/cors.md": [
+      {
+        "hashed_secret": "1e10e8864bfeec80212f07846cfa7def1b4aa38b",
+        "is_verified": false,
+        "line_number": 102,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "api/design_documents.md": [
+      {
+        "hashed_secret": "cab4e6f7701f26807fca957500a5addb244c55c3",
+        "is_verified": false,
+        "line_number": 1207,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "api/document.md": [
+      {
+        "hashed_secret": "455877bc8dc7aa6e2451ca6f10ac952eabac1113",
+        "is_verified": false,
+        "line_number": 1190,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "api/replication.md": [
+      {
+        "hashed_secret": "b9de705384f33efeaeaa5d9ebdd55c03a4c69fce",
+        "is_verified": false,
+        "line_number": 571,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "faqs/authenticating-faq.md": [
+      {
+        "hashed_secret": "bdd3deaade6992c807bd27117b38265580e5dfec",
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64cc2ce9d29355fda5ac89a7f841a4fdde13cd88",
+        "is_verified": false,
+        "line_number": 90,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e412972fd32221dbd8470ad8b18c3906dd1ef51b",
+        "is_verified": false,
+        "line_number": 90,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "getting-started.md": [
+      {
+        "hashed_secret": "7253494cec7f1a836cd1bdc74c271a8a6207a7e5",
+        "is_verified": false,
+        "line_number": 271,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48dea084a4fe72fe18213ec6040dd193b135c45c",
+        "is_verified": false,
+        "line_number": 310,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "guides/active-active.md": [
+      {
+        "hashed_secret": "abd524e8236fb30d6cca79fb2d0f0c3528caa851",
+        "is_verified": false,
+        "line_number": 128,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e0a214fd3c395a21bedbce3fa9748fe638ec9174",
+        "is_verified": false,
+        "line_number": 188,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "guides/backup-guide-using-replication.md": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 485,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "guides/conflicts.md": [
+      {
+        "hashed_secret": "9cd58e176bf51a86195a5dead236289ac38e8834",
+        "is_verified": false,
+        "line_number": 256,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "guides/iam.md": [
+      {
+        "hashed_secret": "bdd3deaade6992c807bd27117b38265580e5dfec",
+        "is_verified": false,
+        "line_number": 122,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0324614db4a9d7a40668f17bd24bb47b259ff8c5",
+        "is_verified": false,
+        "line_number": 134,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "01a5b9a1f3cbb5e89ea18aeba9edfccb0df90b90",
+        "is_verified": false,
+        "line_number": 188,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "01a5b9a1f3cbb5e89ea18aeba9edfccb0df90b90",
+        "is_verified": false,
+        "line_number": 188,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1c2b0d17c738509518ecc6efa233ee6c10e724f2",
+        "is_verified": false,
+        "line_number": 190,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c2df5d3d760ff42f33fb38e2534d4c1b7ddde3ab",
+        "is_verified": false,
+        "line_number": 318,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1d85c5b4ac2b77ed64b5f962767e9e555a9670ab",
+        "is_verified": false,
+        "line_number": 319,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2fe0a983c4dcdea5c7e88f9bbbe47083411771ee",
+        "is_verified": false,
+        "line_number": 376,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "788c214442b1433a8789390a7d89690b98cb89ee",
+        "is_verified": false,
+        "line_number": 384,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64cc2ce9d29355fda5ac89a7f841a4fdde13cd88",
+        "is_verified": false,
+        "line_number": 550,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e412972fd32221dbd8470ad8b18c3906dd1ef51b",
+        "is_verified": false,
+        "line_number": 550,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2308d0fb5ab83a7e92e8000f5f094342d3f87bd0",
+        "is_verified": false,
+        "line_number": 558,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "guides/mvcc.md": [
+      {
+        "hashed_secret": "9cd58e176bf51a86195a5dead236289ac38e8834",
+        "is_verified": false,
+        "line_number": 232,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "guides/pagination-bookmarks.md": [
+      {
+        "hashed_secret": "c2941c57d56abd95410ec023f561f7562346b7af",
+        "is_verified": false,
+        "line_number": 284,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6cd6718d48a526c922d1052576596a7908a61dda",
+        "is_verified": false,
+        "line_number": 312,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "guides/replication_guide.md": [
+      {
+        "hashed_secret": "d631816a4b0988fdfe5042aa222e404ec3f82cc7",
+        "is_verified": false,
+        "line_number": 396,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_verified": false,
+        "line_number": 479,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d28c0fa1088ccf6406cae7cac3ec793c7ada9878",
+        "is_verified": false,
+        "line_number": 612,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "guides/transactions.md": [
+      {
+        "hashed_secret": "59632ddf791ae129db73da8fbbbf63686e3b2eb0",
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "664ba3c9a2edf53fb88f2865ad1da84b849af030",
+        "is_verified": false,
+        "line_number": 147,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "62c2f3b952e91f3a825a5ebe7cd6a2e0344920e1",
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e3c9fc89a7a22f2bdca828fafce5df8da17678de",
+        "is_verified": false,
+        "line_number": 233,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "ignoreLinks.txt": [
+      {
+        "hashed_secret": "e3b1c5a9454a1b14aa1cfe56d05937b4d5d606c5",
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e3b1c5a9454a1b14aa1cfe56d05937b4d5d606c5",
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Cloudant Credentials",
+        "verified_result": null
+      }
+    ],
+    "libraries/thirdparty.md": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 213,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "local/configure.md": [
+      {
+        "hashed_secret": "74ac34b584be7183263fc55e20402a024ce1e1f5",
+        "is_verified": false,
+        "line_number": 576,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "959b39f2449dacb081556dd9252eaeafc64ed03e",
+        "is_verified": false,
+        "line_number": 1199,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d50657fb5275d39ed8eecf51390cfe53f260cc6",
+        "is_verified": false,
+        "line_number": 1223,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3c57fce501056891e214d275d031985e219d3778",
+        "is_verified": false,
+        "line_number": 1240,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "local/maintenance.md": [
+      {
+        "hashed_secret": "04e110541a2e8b44bc10939bfaf5d82adfe45158",
+        "is_verified": false,
+        "line_number": 211,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "716974d84626ec13c870beb602035649f9fb4d14",
+        "is_verified": false,
+        "line_number": 427,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d70835fe7799f546d1fa2a8ff7a6e4cb74be73fe",
+        "is_verified": false,
+        "line_number": 749,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "local/troubleshoot.md": [
+      {
+        "hashed_secret": "ee0a1bee6c72c56c1e1aec59f7d0731f89f619c1",
+        "is_verified": false,
+        "line_number": 336,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "offerings/connecting.md": [
+      {
+        "hashed_secret": "64cc2ce9d29355fda5ac89a7f841a4fdde13cd88",
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e412972fd32221dbd8470ad8b18c3906dd1ef51b",
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "01a5b9a1f3cbb5e89ea18aeba9edfccb0df90b90",
+        "is_verified": false,
+        "line_number": 86,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "01a5b9a1f3cbb5e89ea18aeba9edfccb0df90b90",
+        "is_verified": false,
+        "line_number": 86,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1c2b0d17c738509518ecc6efa233ee6c10e724f2",
+        "is_verified": false,
+        "line_number": 88,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "offerings/learning-center.md": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 425,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "operator/configure_cluster.md": [
+      {
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "operator/deploy_cluster.md": [
+      {
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_verified": false,
+        "line_number": 228,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "operator/install_operator.md": [
+      {
+        "hashed_secret": "6aeef9ee03322724fb7427d117491e7b8f8f098f",
+        "is_verified": false,
+        "line_number": 200,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "012ad335e639383e2b7f461c7289e76caa4a35d8",
+        "is_verified": false,
+        "line_number": 207,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tutorials/create_backup.md": [
+      {
+        "hashed_secret": "41ec2f2b65185392f9accc56e63949033e4c579b",
+        "is_verified": false,
+        "line_number": 328,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d2bd72ffcbf3fb37950ca5e8a4290af96e88c6c2",
+        "is_verified": false,
+        "line_number": 332,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "37e3514d812fc12c846631f2ca053e33a7ca4118",
+        "is_verified": false,
+        "line_number": 336,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b2db7857fde1ce628b7927f0a019c080a112b048",
+        "is_verified": false,
+        "line_number": 340,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c4dcd67c7c25cf2cbc7b286707d93f0c548de586",
+        "is_verified": false,
+        "line_number": 344,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 388,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tutorials/create_database.md": [
+      {
+        "hashed_secret": "2be5615eac3427552bd25a5001bc7eec8c427cfc",
+        "is_verified": false,
+        "line_number": 389,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d992a9890ebf8028aa56006d4c63ad7025f9b021",
+        "is_verified": false,
+        "line_number": 406,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "703696c6968861f0d9e9bd2a2e2e356da58b6981",
+        "is_verified": false,
+        "line_number": 472,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "703696c6968861f0d9e9bd2a2e2e356da58b6981",
+        "is_verified": false,
+        "line_number": 472,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tutorials/create_dedicated_hardware_plan.md": [
+      {
+        "hashed_secret": "9e7d6b70d1730ed580460d8cb68d70fb8bd3d41e",
+        "is_verified": false,
+        "line_number": 215,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e3b1c5a9454a1b14aa1cfe56d05937b4d5d606c5",
+        "is_verified": false,
+        "line_number": 346,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cee709eb212cc6e9dc525398000738e78e00293d",
+        "is_verified": false,
+        "line_number": 349,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2b1e829d4ec4f621e9100f5d4dc776a93922943f",
+        "is_verified": false,
+        "line_number": 353,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tutorials/create_query.md": [
+      {
+        "hashed_secret": "b0ea8d3554cef9e9cafaa1e0656fc0fec5fe83b5",
+        "is_verified": false,
+        "line_number": 629,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tutorials/create_service_cli.md": [
+      {
+        "hashed_secret": "9e7d6b70d1730ed580460d8cb68d70fb8bd3d41e",
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e3b1c5a9454a1b14aa1cfe56d05937b4d5d606c5",
+        "is_verified": false,
+        "line_number": 268,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cee709eb212cc6e9dc525398000738e78e00293d",
+        "is_verified": false,
+        "line_number": 271,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2b1e829d4ec4f621e9100f5d4dc776a93922943f",
+        "is_verified": false,
+        "line_number": 275,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: update-secrets
+
+update-secrets:
+	@echo "🚀 Starting detect-secrets workflow..."
+
+	# 🧼 Clean any existing virtual environment
+	@echo "🧹 Cleaning old virtual environment (if any)..."
+	@rm -rf .venv-ds
+
+	# 🛠️  Set up a new virtual environment
+	@echo "🐍 Creating fresh virtual environment at .venv-ds..."
+	@python3 -m venv .venv-ds
+
+	# 📦 Upgrade pip silently
+	@echo "📦 Upgrading pip..."
+	@.venv-ds/bin/pip install --upgrade pip > /dev/null
+
+	# 🔍 Install latest detect-secrets
+	@echo "🔐 Installing detect-secrets..."
+	@.venv-ds/bin/pip install git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets > /dev/null
+
+	# 📊 Scan and update the baseline
+	@echo "🔎 Scanning for secrets and updating .secrets.baseline..."
+	@.venv-ds/bin/detect-secrets scan --update .secrets.baseline --suppress-unscannable-file-warnings
+
+	# 🧽 Cleanup the virtual environment
+	@echo "🧼 Removing virtual environment..."
+	@rm -rf .venv-ds
+
+	@echo "✅ Done! .secrets.baseline is updated."

--- a/README.md
+++ b/README.md
@@ -28,3 +28,25 @@ Please use https://github.ibm.com/cloud-docs/Cloudant for contributions to the d
 
 If you are not an IBM employee and want to make a documentation contribution, go to the [IBM Cloudant documentation](https://cloud.ibm.com/docs/services/Cloudant?topic=cloudant-getting-started-with-cloudant#getting-started-with-cloudant) and click `Feedback` on the page where you want to comment. 
 
+# 🔐 Detect Secrets Enforcement
+
+This repository uses [`detect-secrets`](https://github.com/IBM/detect-secrets-stream) to prevent committing sensitive information like API keys, tokens, and passwords.
+
+## 🚀 How It Works
+
+Secrets are tracked using a `.secrets.baseline` file. This file contains a hash of detected secret patterns and is version-controlled.
+
+On every pull request, GitHub Actions will:
+- Scan the codebase using the committed baseline.
+- Fail the build if new untracked secrets are found.
+
+## 🛠 Update the Baseline
+
+If your PR is failing due to newly detected secrets (false positives or intentional additions), follow the steps below to update the baseline:
+
+### ✅ One-Command Update
+
+Use the provided `Makefile` to automatically install and run `detect-secrets`, then clean up:
+
+```bash
+make update-secrets


### PR DESCRIPTION
Issue: https://github.ibm.com/cloudant/releng/issues/1062

Added GitHub Action to scan secrets on PRs
Included Makefile for easy baseline updates
Auto-installs detect-secrets and cleans up
Added short README for developer usage
Configured baseline with exclusions and plugin tweaks